### PR TITLE
Update the value for the Joe entry to be merged

### DIFF
--- a/collection-interfaces/src/test/java/collection/interfaces/Exercise2Test.java
+++ b/collection-interfaces/src/test/java/collection/interfaces/Exercise2Test.java
@@ -56,7 +56,7 @@ public class Exercise2Test {
         Map<String, Integer> map = new HashMap<>(this.map);
 
         /**
-         * Merge 2 entry to {@link map} with key="Alice" value=32, key="Joe" value=54 using {@link Map#merge}.
+         * Merge 2 entry to {@link map} with key="Alice" value=32, key="Joe" value=32 using {@link Map#merge}.
          * If the value already exist for the key, remap with sum value.
          */
         BiFunction<Object, Object, Integer> remappingFunction = null;


### PR DESCRIPTION
54 is the value resulting from the merge whereas 32 is the value associated to the entry to merge (if existing)
It misleads the developper as he will write map.merge("Joe", 54, remappingFunction); instead of map.merge("Joe", 32, remappingFunction);