### PR TITLE
Correct misleading plusDays to plusMonths in excercise

### DIFF
--- a/date-and-time-api/src/test/java/date/and/time/api/Exercise1Test.java
+++ b/date-and-time-api/src/test/java/date/and/time/api/Exercise1Test.java
@@ -76,7 +76,7 @@ public class Exercise1Test {
 
         /**
          * Create a {@link LocalDate} from {@link ld} with 10 month later
-         * by using {@link LocalDate#plusDays} or {@link LocalDate#plus}
+         * by using {@link LocalDate#plusMonths} or {@link LocalDate#plus}
          */
         LocalDate localDate = null;
 


### PR DESCRIPTION
In Exercise1Test in date-and-time-api there is a misleading tip in exercise 5