### PR TITLE
Fix a wrong variable name in an exercise

### DIFF
--- a/stream-api/src/test/java/stream/api/Exercise1Test.java
+++ b/stream-api/src/test/java/stream/api/Exercise1Test.java
@@ -49,8 +49,8 @@ public class Exercise1Test extends ClassicOnlineStore {
         Stream<Integer> ageStream = null;
 
         assertTrue(AssertUtil.isLambda(getAgeFunction));
-        List<Integer> richCustomer = ageStream.collect(Collectors.toList());
-        assertThat(richCustomer, hasSize(10));
-        assertThat(richCustomer, contains(22, 27, 28, 38, 26, 22, 32, 35, 21, 36));
+        List<Integer> ages = ageStream.collect(Collectors.toList());
+        assertThat(ages, hasSize(10));
+        assertThat(ages, contains(22, 27, 28, 38, 26, 22, 32, 35, 21, 36));
     }
 }


### PR DESCRIPTION
Hi. 

Thank you very much for theses Java 8 exercices. It helps me a lot.

I'm just proposing this very small contribution to make it absolutly perfect :
In the first Exercise of the stream serie, the "ages" actual list was mislabeled "richCustomer".